### PR TITLE
Reverse parameters for sender message key limit check.

### DIFF
--- a/libaxolotl/SessionCipher.cs
+++ b/libaxolotl/SessionCipher.cs
@@ -365,7 +365,9 @@ namespace libaxolotl
                 }
             }
 
-            if (counter - chainKey.getIndex() > 2000)
+            //Avoiding a uint overflow
+            uint chainKeyIndex = chainKey.getIndex();
+            if ((counter > chainKeyIndex) && (counter - chainKeyIndex > 2000))
             {
                 throw new InvalidMessageException("Over 2000 messages into the future!");
             }

--- a/libaxolotl/groups/GroupCipher.cs
+++ b/libaxolotl/groups/GroupCipher.cs
@@ -155,17 +155,14 @@ namespace libaxolotl.groups
                 }
             }
 
-			//Avoiding a uint overflow
-			uint sckIteration = senderChainKey.getIteration();
-			if(sckIteration > iteration)
-			{
-				if (sckIteration - iteration > 2000)
-				{
-					throw new InvalidMessageException("Over 2000 messages into the future!");
-				}
-			}
+            //Avoiding a uint overflow
+            uint senderChainKeyIteration = senderChainKey.getIteration();
+            if ((iteration > senderChainKeyIteration) && (iteration - senderChainKeyIteration > 2000))
+            {
+                throw new InvalidMessageException("Over 2000 messages into the future!");
+            }
 
-			while (senderChainKey.getIteration() < iteration)
+            while (senderChainKey.getIteration() < iteration)
 			{
 				senderKeyState.addSenderMessageKey(senderChainKey.getSenderMessageKey());
 				senderChainKey = senderChainKey.getNext();


### PR DESCRIPTION
fix for https://github.com/langboost/libaxolotl-uwp/issues/5
